### PR TITLE
Add  intraday (10 day) forecast

### DIFF
--- a/weather/weather_insights.html
+++ b/weather/weather_insights.html
@@ -41,6 +41,7 @@
         <label for="node-input-service"><i class="fa fa-question"></i> Service</label>
         <select type="text" id="node-input-service" style="display: inline-block; width: 70%;" >
             <option value="/forecast/daily/10day.json">Daily Forecast (10 Days)</option>
+            <option value="/forecast/intraday/10day.json">Intraday Forecast (10 Days)</option>            
             <option value="/forecast/hourly/48hour.json">Hourly Forecast (48 Hours)</option>
             <option value="/observations.json">Current Observations</option>
             <option value="/observations/timeseries.json?hours=23">Historic Observations (24 Hours)</option>


### PR DESCRIPTION
As discussed with Dave in slack - added a missing  Weather Company  API  (intraday)  to the node.
Its tested local and should work .   Adding the  3 / 5 / 7 day apis does not give additional value since they just  give the same data back  (only shorter array)  
Greetings Michael